### PR TITLE
Generally avoid issues when installing zypper fails, refresh package lists at the beginning, too, so that it doesn't fail

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -26,7 +26,7 @@ then
   echo "Found installed zypper"
 else
   echo "Installing zypper"
-  pkcon -y install zypper
+  pkcon -y install zypper || exit 1
 fi
 
 echo "Stopping pkackagekit"
@@ -44,7 +44,7 @@ echo " if you asked to choose y/n/c or similar:"
 echo " type y and ENTER"
 echo "----- IMPORTANT -----"
 echo ""
-zypper in feature-jolla sailfish-content-configuration-jolla sailfish-content-graphics-jolla-z1.25 sailfish-content-apps-default-configs sailfish-content-ambiences-default
+zypper in feature-jolla sailfish-content-configuration-jolla sailfish-content-graphics-jolla-z1.25 sailfish-content-apps-default-configs sailfish-content-ambiences-default || exit 2
 
 echo "Removing intex packages"
 

--- a/script.sh
+++ b/script.sh
@@ -69,6 +69,7 @@ echo "Refreshing package lists"
 pkcon refresh
 
 echo "Telling system we're Jolla C now"
+# This is indeed necessary even if the file already exists
 touch /usr/share/ssu/board-mappings.d/10-l500d-jolla.ini
 
 echo "Done!"

--- a/script.sh
+++ b/script.sh
@@ -61,6 +61,7 @@ zypper rm feature-intex sailfish-content-configuration-intex sailfish-content-ap
 echo "Restarting ambience service"
 systemctl-user restart ambienced
 
+echo "Refreshing package lists"
 pkcon refresh
 
 echo "Telling system we're Jolla C now"

--- a/script.sh
+++ b/script.sh
@@ -61,6 +61,8 @@ zypper rm feature-intex sailfish-content-configuration-intex sailfish-content-ap
 echo "Restarting ambience service"
 systemctl-user restart ambienced
 
+pkcon refresh
+
 echo "Telling system we're Jolla C now"
 touch /usr/share/ssu/board-mappings.d/10-l500d-jolla.ini
 

--- a/script.sh
+++ b/script.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Make sure we have up to date repos, otherwise some dependencies might not be found
+echo "Refreshing package lists to make sure zypper is installable"
+pkcon refresh
+
 if [ ! -f /usr/share/ssu/features.d/customer-jolla.ini ]; then
 echo "Injecting jolla repository"
 cat >/usr/share/ssu/features.d/customer-jolla.ini <<EOL


### PR DESCRIPTION
When I ran the script on my Intex Aqua Fish today, installing `zypper` failed for me as follows:

```
Resolving                                                                                                
Testing changes                                                                                          
Finished                                                       [                               ] (0%)  
The following packages have to be installed:
 augeas-libs-1.0.0-1.1.4.armv7hl        Libraries for augeas
 zypper-1.8.3-1.1.38.armv7hl    Command line software manager using libzypp
Proceed with changes? [N/y] y

                                                                                                        
Installing                                                                                               
Starting                                                                                                 
Refreshing software list                                                                                
Querying                                                                                                
Resolving dependencies                                                                                  
Downloading packages                                                                                    
Finished                                                                                                
Fatal error: File './core/armv7hl/augeas-libs-1.0.0-1.1.4.armv7hl.rpm' not found on medium 'https://releases.jolla.com/releases/2.1.4.14/jolla/armv7hl/'
```

Nevertheless the script continued to run, changing further stuff despite a lots of things didn't work as can be seen on this screenshot: ![failed-aqua-fish-to-jolla-c_script sh](https://user-images.githubusercontent.com/241094/48318660-321fc280-e604-11e8-95f6-e60036720f57.jpg)

So this pull request fixes multiple things:

* Run `pkcon refresh` at the very beginning.
* Abort if installation of `zypper` or Jolla-C-specific packages fails
* Include the rebased commit from #1 with extended commit message mentioning the specific issue it fixes.
* Add a code comment that the `touch` command at the very end is even necessary if the file already exists. (Ran into the issue that the device still considered itself an Intex Aqua Fish because I didn't run the `touch` command as the file already existed when I was fixing up the breakage caused by zypper being uninstallable and hence calling every remaining steps of the script manually.)